### PR TITLE
[finishes #174198645] add check for null rootcode to convert to STK

### DIFF
--- a/app_main/src/main/java/com/hover/runner/utils/Utils.java
+++ b/app_main/src/main/java/com/hover/runner/utils/Utils.java
@@ -72,6 +72,8 @@ public class Utils {
         Gson gson = new Gson();
         RawStepsModel[] rawStepsModel = gson.fromJson(String.valueOf(jsonArray), RawStepsModel[].class);
 
+        if(rootCode.contains("null")) rootCode = "STK#";
+
         StringBuilder stepSuffix = new StringBuilder();
         ArrayList<String> stepsVariableLabels = new ArrayList<>();
         ArrayList<String> stepsVariableDesc = new ArrayList<>();


### PR DESCRIPTION
The root code is passed as a string based on the what the SDK reports. Anytime it reports a nulled root code, it changes it to STK. e.g STK*1#